### PR TITLE
Enable lib check

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "lint": "run-p lint:**",
     "lint:prettier": "prettier --check .",
     "lint:eslint": "eslint --ext .ts .",
-    "lint:tsc:src": "tsc -p src",
-    "lint:tsc:tools": "tsc -p tools",
+    "lint:tsc:src": "tsc -p src --skipLibCheck",
+    "lint:tsc:tools": "tsc -p tools --skipLibCheck",
     "test": "jest --config src/jest.config.ts",
     "ci": "run-p lint test"
   },

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -5,7 +5,6 @@
     "lib": ["esnext", "dom", "webworker"],
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "sourceMap": true,
     "noEmit": true

--- a/src/types/pngjs.d.ts
+++ b/src/types/pngjs.d.ts
@@ -1,3 +1,3 @@
-module "pngjs/browser" {
+declare module "pngjs/browser" {
   export * from "pngjs";
 }

--- a/src/types/webworker.d.ts
+++ b/src/types/webworker.d.ts
@@ -1,7 +1,6 @@
-// Workaround for weird semver of typescript :(
+// @ts-expect-error Workaround for weird semver of typescript
 // See https://github.com/microsoft/TypeScript/issues/45745
 // Copy from https://github.com/microsoft/TypeScript/blob/v4.3.5/lib/lib.webworker.d.ts
-// @ts-nocheck
 class OffscreenCanvas extends EventTarget {
   constructor(width: number, height: number);
   /**

--- a/src/types/webworker.d.ts
+++ b/src/types/webworker.d.ts
@@ -1,6 +1,7 @@
 // Workaround for weird semver of typescript :(
 // See https://github.com/microsoft/TypeScript/issues/45745
 // Copy from https://github.com/microsoft/TypeScript/blob/v4.3.5/lib/lib.webworker.d.ts
+// @ts-nocheck
 class OffscreenCanvas extends EventTarget {
   constructor(width: number, height: number);
   /**

--- a/tools/generate-jsons.ts
+++ b/tools/generate-jsons.ts
@@ -2,7 +2,7 @@ import { promises as fs } from "fs";
 import * as path from "path";
 import glob from "glob-promise";
 import { BlockId, BlockIdNames, parseNim } from "./lib/nim-parser";
-import { LabelId, parseLabel } from "./lib/label-parser";
+import { parseLabel } from "./lib/label-parser";
 import { parseTts } from "./lib/tts-parser";
 import * as utils from "./lib/utils";
 

--- a/tools/generate-prefab-html.ts
+++ b/tools/generate-prefab-html.ts
@@ -2,7 +2,7 @@ import * as path from "path";
 import { promises as fs } from "fs";
 import glob from "glob-promise";
 import { prefabHtml } from "./lib/prefab-html";
-import { LabelId, parseLabel } from "./lib/label-parser";
+import { parseLabel } from "./lib/label-parser";
 import { handleMain, projectRoot, vanillaDir } from "./lib/utils";
 
 const BASE_DEST = projectRoot("docs", "prefabs");

--- a/tools/lib/label-parser.ts
+++ b/tools/lib/label-parser.ts
@@ -1,8 +1,6 @@
 import fs from "fs";
 import { Parser, parse as csvParse } from "csv-parse";
 
-export type LabelId = string;
-
 const LANGUAGES: Languages = [
   "english",
   "german",

--- a/tools/lib/prefab-html.ts
+++ b/tools/lib/prefab-html.ts
@@ -2,7 +2,6 @@ import * as path from "path";
 import { parseNim } from "./nim-parser";
 import { parseTts } from "./tts-parser";
 import { parseXml } from "./xml-parser";
-import { LabelId } from "./label-parser";
 
 interface HtmlModel {
   name: string;

--- a/tools/tsconfig.json
+++ b/tools/tsconfig.json
@@ -5,7 +5,6 @@
     "lib": ["es2020"],
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true
   }

--- a/tools/types/label.d.ts
+++ b/tools/types/label.d.ts
@@ -1,4 +1,4 @@
-const LANGUAGES = [
+type Languages = [
   "english",
   "german",
   "spanish",
@@ -11,10 +11,10 @@ const LANGUAGES = [
   "russian",
   "turkish",
   "schinese",
-  "tchinese",
-] as const;
+  "tchinese"
+];
 
-type Languages = typeof LANGUAGES;
+type LabelId = string;
 
 type LabelCore = {
   [lang in Languages[number]]: string;


### PR DESCRIPTION
Lib-check works only in editing but stop on linting because we cannot fix the errors from `node_modules`.

See https://github.com/microsoft/TypeScript/issues/30511