### PR TITLE
Reduce memory usage: composite-only cache for map layers

### DIFF
--- a/lib/map-files.ts
+++ b/lib/map-files.ts
@@ -47,14 +47,14 @@ const FILE_PROCESS_RULES = {
 } as const;
 
 export type WorldFileName = keyof typeof FILE_PROCESS_RULES;
-export type MapFileNameMap<T extends keyof typeof FILE_PROCESS_RULES> =
-  (typeof FILE_PROCESS_RULES)[T]["name"];
-export const MAP_FILE_NAME_MAP = Object.fromEntries(
-  Object.entries(FILE_PROCESS_RULES).map(([k, v]) => [k, v.name]),
-) as {
-  [K in WorldFileName]: MapFileNameMap<K>;
-};
-export type MapFileName = MapFileNameMap<WorldFileName>;
+export type MapFileName = (typeof FILE_PROCESS_RULES)[WorldFileName]["name"];
+
+export const MAP_IMAGE_FILE_NAMES = [
+  "biomes.png",
+  "splat3.png",
+  "splat4.png",
+  "radiation.png",
+] as const satisfies readonly MapFileName[];
 
 export class Processor<T extends keyof typeof FILE_PROCESS_RULES> {
   #worldFileName: T;
@@ -63,7 +63,7 @@ export class Processor<T extends keyof typeof FILE_PROCESS_RULES> {
     this.#worldFileName = worldFileName;
   }
 
-  get mapFileName(): MapFileNameMap<T> {
+  get mapFileName(): MapFileName {
     return FILE_PROCESS_RULES[this.#worldFileName].name;
   }
 
@@ -89,19 +89,11 @@ export const MAP_FILE_NAMES = new Set(
   Object.values(FILE_PROCESS_RULES).map((v) => v.name),
 );
 
-export function isMapFileName(
-  name: string,
-): name is MapFileNameMap<WorldFileName> {
-  return MAP_FILE_NAMES.has(
-    name as unknown as (typeof FILE_PROCESS_RULES)[
-      keyof typeof FILE_PROCESS_RULES
-    ]["name"],
-  );
+export function isMapFileName(name: string): name is MapFileName {
+  return MAP_FILE_NAMES.has(name as MapFileName);
 }
 
-export function getMapFileName(
-  name: WorldFileName,
-): MapFileNameMap<WorldFileName> {
+export function getMapFileName(name: WorldFileName): MapFileName {
   return FILE_PROCESS_RULES[name].name;
 }
 

--- a/src/worker/lib/map-renderer.ts
+++ b/src/worker/lib/map-renderer.ts
@@ -16,6 +16,13 @@ interface FontFamilies {
   [MARK_CHAR]: string;
 }
 
+const MAP_FILE_NAMES = [
+  "biomes.png",
+  "splat3.png",
+  "splat4.png",
+  "radiation.png",
+] as const satisfies readonly mapFiles.MapFileName[];
+
 export default class MapRenderer {
   brightness = "100%";
   markerCoords: GameCoords | null = null;
@@ -31,18 +38,12 @@ export default class MapRenderer {
 
   canvas: OffscreenCanvas;
   #mapSize = gameMapSize({ width: 0, height: 0 });
-
-  #biomesImage = new MapLayerImage("biomes.png");
-  #splat3Image = new MapLayerImage("splat3.png");
-  #splat4Image = new MapLayerImage("splat4.png");
-  #radImage = new MapLayerImage("radiation.png");
-  #imageFiles = [
-    this.#biomesImage,
-    this.#splat3Image,
-    this.#splat4Image,
-    this.#radImage,
-  ] as const;
   #fontFamilies: FontFamilies;
+
+  #nativeSizes = new Map<
+    mapFiles.MapFileName,
+    { width: number; height: number }
+  >();
 
   // Composited base map (layers + brightness + per-layer alpha) cached so that
   // prefab/marker-only updates can skip recompositing.
@@ -60,22 +61,7 @@ export default class MapRenderer {
     fileNames: ("biomes.png" | "splat3.png" | "splat4.png" | "radiation.png")[],
   ) {
     for (const fileName of fileNames) {
-      switch (fileName) {
-        case "biomes.png":
-          this.#biomesImage.invalidate();
-          break;
-        case "splat3.png":
-          this.#splat3Image.invalidate();
-          break;
-        case "splat4.png":
-          this.#splat4Image.invalidate();
-          break;
-        case "radiation.png":
-          this.#radImage.invalidate();
-          break;
-        default:
-          throw new Error(`Invalid file name: ${String(fileName)}`);
-      }
+      this.#nativeSizes.delete(fileName);
     }
     this.#generation++;
   }
@@ -89,7 +75,7 @@ export default class MapRenderer {
 
   async #updateImmediately(): Promise<void> {
     const sizes = await Promise.all(
-      this.#imageFiles.map((i) => i.nativeSize()),
+      MAP_FILE_NAMES.map((f) => this.#nativeSize(f)),
     );
     const { width, height } = mapSize(...sizes);
     this.#mapSize.width = width;
@@ -165,10 +151,10 @@ export default class MapRenderer {
     if (!context) throw new Error("Failed to get 2d context");
 
     const [biomes, splat3, splat4, rad] = await Promise.all([
-      this.#biomesImage.decode(width, height),
-      this.#splat3Image.decode(width, height),
-      this.#splat4Image.decode(width, height),
-      this.#radImage.decode(width, height),
+      this.#decode("biomes.png", width, height),
+      this.#decode("splat3.png", width, height),
+      this.#decode("splat4.png", width, height),
+      this.#decode("radiation.png", width, height),
     ]);
 
     try {
@@ -254,6 +240,50 @@ export default class MapRenderer {
     putText(context, { text: MARK_CHAR, x, z, size: this.signSize });
   }
 
+  async #nativeSize(
+    fileName: mapFiles.MapFileName,
+  ): Promise<{ width: number; height: number } | null> {
+    const cached = this.#nativeSizes.get(fileName);
+    if (cached) return cached;
+    const file = await this.#getFile(fileName);
+    if (!file) return null;
+    const size = await readPngSize(file);
+    this.#nativeSizes.set(fileName, size);
+    return size;
+  }
+
+  async #decode(
+    fileName: mapFiles.MapFileName,
+    width: number,
+    height: number,
+  ): Promise<ImageBitmap | null> {
+    if (width <= 0 || height <= 0) return null;
+    const file = await this.#getFile(fileName);
+    if (!file) return null;
+    console.time(`Loading image ${fileName}`);
+    try {
+      const result = await createImageBitmap(file, {
+        resizeWidth: width,
+        resizeHeight: height,
+        resizeQuality: "high",
+      });
+      console.log("Loaded image", fileName, width, height);
+      return result;
+    } catch (e) {
+      const extra = `(size: ${file.size} bytes, type: ${file.type})`;
+      throw new Error(`Failed to decode image: ${fileName} ${extra}`, {
+        cause: e,
+      });
+    } finally {
+      console.timeEnd(`Loading image ${fileName}`);
+    }
+  }
+
+  async #getFile(fileName: mapFiles.MapFileName): Promise<File | null> {
+    const workspace = await storage.workspaceDir();
+    return workspace.get(fileName);
+  }
+
   size(): GameMapSize {
     return this.#mapSize;
   }
@@ -288,60 +318,6 @@ function putText(
   context.strokeText(text, x, z);
 
   context.fillText(text, x, z);
-}
-
-/**
- * Accesses a source map image, decoding it at the requested display resolution
- * rather than at full resolution. The decoded bitmap is NOT retained: the
- * caller owns the returned bitmap and must close() it. Only the native
- * dimensions (read cheaply from the PNG header) are memoized. This keeps just
- * the single composited surface in memory, at the cost of re-decoding the
- * layers whenever the composite is rebuilt.
- */
-class MapLayerImage {
-  #nativeSize: { width: number; height: number } | null = null;
-
-  constructor(readonly fileName: mapFiles.MapFileName) {}
-
-  invalidate() {
-    this.#nativeSize = null;
-  }
-
-  async nativeSize(): Promise<{ width: number; height: number } | null> {
-    if (this.#nativeSize) return this.#nativeSize;
-    const file = await this.#getFile();
-    if (!file) return null;
-    this.#nativeSize = await readPngSize(file);
-    return this.#nativeSize;
-  }
-
-  async decode(width: number, height: number): Promise<ImageBitmap | null> {
-    if (width <= 0 || height <= 0) return null;
-    const file = await this.#getFile();
-    if (!file) return null;
-    console.time(`Loading image ${this.fileName}`);
-    try {
-      const result = await createImageBitmap(file, {
-        resizeWidth: width,
-        resizeHeight: height,
-        resizeQuality: "high",
-      });
-      console.log("Loaded image", this.fileName, width, height);
-      return result;
-    } catch (e) {
-      const extra = `(size: ${file.size} bytes, type: ${file.type})`;
-      throw new Error(`Failed to decode image: ${this.fileName} ${extra}`, {
-        cause: e,
-      });
-    } finally {
-      console.timeEnd(`Loading image ${this.fileName}`);
-    }
-  }
-
-  async #getFile(): Promise<File | null> {
-    const workspace = await storage.workspaceDir();
-    return workspace.get(this.fileName);
-  }
 }
 
 /**

--- a/src/worker/lib/map-renderer.ts
+++ b/src/worker/lib/map-renderer.ts
@@ -7,7 +7,6 @@ import { throttledInvoker } from "../../lib/throttled-invoker.ts";
 import { gameMapSize } from "../../lib/utils.ts";
 import * as storage from "../../lib/storage.ts";
 import * as mapFiles from "../../../lib/map-files.ts";
-import { CacheHolder } from "../../lib/cache-holder.ts";
 
 const SIGN_CHAR = "✘";
 const MARK_CHAR = "🚩";
@@ -33,10 +32,10 @@ export default class MapRenderer {
   canvas: OffscreenCanvas;
   #mapSize = gameMapSize({ width: 0, height: 0 });
 
-  #biomesImage = new ScaledImageHolder("biomes.png");
-  #splat3Image = new ScaledImageHolder("splat3.png");
-  #splat4Image = new ScaledImageHolder("splat4.png");
-  #radImage = new ScaledImageHolder("radiation.png");
+  #biomesImage = new MapLayerImage("biomes.png");
+  #splat3Image = new MapLayerImage("splat3.png");
+  #splat4Image = new MapLayerImage("splat4.png");
+  #radImage = new MapLayerImage("radiation.png");
   #imageFiles = [
     this.#biomesImage,
     this.#splat3Image,
@@ -159,37 +158,43 @@ export default class MapRenderer {
       return this.#composite;
     }
 
-    const [biomes, splat3, splat4, rad] = await Promise.all([
-      this.#biomesImage.get(width, height),
-      this.#splat3Image.get(width, height),
-      this.#splat4Image.get(width, height),
-      this.#radImage.get(width, height),
-    ]);
-
     const canvas = this.#composite ?? new OffscreenCanvas(width, height);
     canvas.width = width;
     canvas.height = height;
     const context = canvas.getContext("2d");
     if (!context) throw new Error("Failed to get 2d context");
-    context.clearRect(0, 0, width, height);
-    context.filter = `brightness(${this.brightness})`;
 
-    if (biomes && this.biomesAlpha !== 0) {
-      context.globalAlpha = this.biomesAlpha;
-      context.drawImage(biomes, 0, 0);
-    }
-    if (splat3 && this.splat3Alpha !== 0) {
-      context.globalAlpha = this.splat3Alpha;
-      context.drawImage(splat3, 0, 0);
-    }
-    if (splat4 && this.splat4Alpha !== 0) {
-      context.globalAlpha = this.splat4Alpha;
-      context.drawImage(splat4, 0, 0);
-    }
-    context.filter = "none";
-    if (rad && this.radAlpha !== 0) {
-      context.globalAlpha = this.radAlpha;
-      context.drawImage(rad, 0, 0);
+    const [biomes, splat3, splat4, rad] = await Promise.all([
+      this.#biomesImage.decode(width, height),
+      this.#splat3Image.decode(width, height),
+      this.#splat4Image.decode(width, height),
+      this.#radImage.decode(width, height),
+    ]);
+
+    try {
+      context.clearRect(0, 0, width, height);
+      context.filter = `brightness(${this.brightness})`;
+
+      if (biomes && this.biomesAlpha !== 0) {
+        context.globalAlpha = this.biomesAlpha;
+        context.drawImage(biomes, 0, 0);
+      }
+      if (splat3 && this.splat3Alpha !== 0) {
+        context.globalAlpha = this.splat3Alpha;
+        context.drawImage(splat3, 0, 0);
+      }
+      if (splat4 && this.splat4Alpha !== 0) {
+        context.globalAlpha = this.splat4Alpha;
+        context.drawImage(splat4, 0, 0);
+      }
+      context.filter = "none";
+      if (rad && this.radAlpha !== 0) {
+        context.globalAlpha = this.radAlpha;
+        context.drawImage(rad, 0, 0);
+      }
+    } finally {
+      // Only the composite is cached; release the per-layer bitmaps.
+      for (const bitmap of [biomes, splat3, splat4, rad]) bitmap?.close();
     }
 
     this.#composite = canvas;
@@ -286,28 +291,20 @@ function putText(
 }
 
 /**
- * Holds a source map image, decoding it lazily at the requested display
- * resolution rather than at full resolution. The decoded bitmap is cached
- * (with TTL) and re-decoded only when the requested size changes or the
- * source image is invalidated, keeping memory proportional to the displayed
- * size instead of the native image size.
+ * Accesses a source map image, decoding it at the requested display resolution
+ * rather than at full resolution. The decoded bitmap is NOT retained: the
+ * caller owns the returned bitmap and must close() it. Only the native
+ * dimensions (read cheaply from the PNG header) are memoized. This keeps just
+ * the single composited surface in memory, at the cost of re-decoding the
+ * layers whenever the composite is rebuilt.
  */
-class ScaledImageHolder {
-  #targetWidth = 0;
-  #targetHeight = 0;
+class MapLayerImage {
   #nativeSize: { width: number; height: number } | null = null;
-  #holder: CacheHolder<ImageBitmap | null>;
 
-  constructor(readonly fileName: mapFiles.MapFileName) {
-    this.#holder = new CacheHolder<ImageBitmap | null>(
-      () => this.#decode(),
-      (img) => img?.close(),
-    );
-  }
+  constructor(readonly fileName: mapFiles.MapFileName) {}
 
   invalidate() {
     this.#nativeSize = null;
-    this.#holder.invalidate();
   }
 
   async nativeSize(): Promise<{ width: number; height: number } | null> {
@@ -318,28 +315,12 @@ class ScaledImageHolder {
     return this.#nativeSize;
   }
 
-  get(width: number, height: number): Promise<ImageBitmap | null> {
-    if (width !== this.#targetWidth || height !== this.#targetHeight) {
-      this.#targetWidth = width;
-      this.#targetHeight = height;
-      this.#holder.invalidate();
-    }
-    return this.#holder.get();
-  }
-
-  async #getFile(): Promise<File | null> {
-    const workspace = await storage.workspaceDir();
-    return workspace.get(this.fileName);
-  }
-
-  async #decode(): Promise<ImageBitmap | null> {
-    const width = this.#targetWidth;
-    const height = this.#targetHeight;
+  async decode(width: number, height: number): Promise<ImageBitmap | null> {
     if (width <= 0 || height <= 0) return null;
-    console.time(`Loading image ${this.fileName}`);
     const file = await this.#getFile();
+    if (!file) return null;
+    console.time(`Loading image ${this.fileName}`);
     try {
-      if (!file) return null;
       const result = await createImageBitmap(file, {
         resizeWidth: width,
         resizeHeight: height,
@@ -348,15 +329,18 @@ class ScaledImageHolder {
       console.log("Loaded image", this.fileName, width, height);
       return result;
     } catch (e) {
-      const extra = file
-        ? `(size: ${file.size} bytes, type: ${file.type})`
-        : "(file not found)";
+      const extra = `(size: ${file.size} bytes, type: ${file.type})`;
       throw new Error(`Failed to decode image: ${this.fileName} ${extra}`, {
         cause: e,
       });
     } finally {
       console.timeEnd(`Loading image ${this.fileName}`);
     }
+  }
+
+  async #getFile(): Promise<File | null> {
+    const workspace = await storage.workspaceDir();
+    return workspace.get(this.fileName);
   }
 }
 

--- a/src/worker/lib/map-renderer.ts
+++ b/src/worker/lib/map-renderer.ts
@@ -16,13 +16,6 @@ interface FontFamilies {
   [MARK_CHAR]: string;
 }
 
-const MAP_FILE_NAMES = [
-  "biomes.png",
-  "splat3.png",
-  "splat4.png",
-  "radiation.png",
-] as const satisfies readonly mapFiles.MapFileName[];
-
 export default class MapRenderer {
   brightness = "100%";
   markerCoords: GameCoords | null = null;
@@ -75,7 +68,7 @@ export default class MapRenderer {
 
   async #updateImmediately(): Promise<void> {
     const sizes = await Promise.all(
-      MAP_FILE_NAMES.map((f) => this.#nativeSize(f)),
+      mapFiles.MAP_IMAGE_FILE_NAMES.map((f) => this.#nativeSize(f)),
     );
     const { width, height } = mapSize(...sizes);
     this.#mapSize.width = width;
@@ -150,12 +143,9 @@ export default class MapRenderer {
     const context = canvas.getContext("2d");
     if (!context) throw new Error("Failed to get 2d context");
 
-    const [biomes, splat3, splat4, rad] = await Promise.all([
-      this.#decode("biomes.png", width, height),
-      this.#decode("splat3.png", width, height),
-      this.#decode("splat4.png", width, height),
-      this.#decode("radiation.png", width, height),
-    ]);
+    const [biomes, splat3, splat4, rad] = await Promise.all(
+      mapFiles.MAP_IMAGE_FILE_NAMES.map((f) => this.#decode(f, width, height)),
+    );
 
     try {
       context.clearRect(0, 0, width, height);

--- a/src/worker/lib/map-renderer.ts
+++ b/src/worker/lib/map-renderer.ts
@@ -105,7 +105,7 @@ export default class MapRenderer {
     const canvasHeight = Math.max(1, Math.round(height * this.scale));
 
     const context = this.canvas.getContext("2d");
-    if (!context) return;
+    if (!context) throw new Error("Failed to get 2d context");
 
     // Compose the base map (which may re-decode at the new size) before
     // touching the visible canvas. Resizing the canvas clears it, so doing it
@@ -169,27 +169,27 @@ export default class MapRenderer {
     const canvas = this.#composite ?? new OffscreenCanvas(width, height);
     canvas.width = width;
     canvas.height = height;
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return null;
-    ctx.clearRect(0, 0, width, height);
-    ctx.filter = `brightness(${this.brightness})`;
+    const context = canvas.getContext("2d");
+    if (!context) throw new Error("Failed to get 2d context");
+    context.clearRect(0, 0, width, height);
+    context.filter = `brightness(${this.brightness})`;
 
     if (biomes && this.biomesAlpha !== 0) {
-      ctx.globalAlpha = this.biomesAlpha;
-      ctx.drawImage(biomes, 0, 0);
+      context.globalAlpha = this.biomesAlpha;
+      context.drawImage(biomes, 0, 0);
     }
     if (splat3 && this.splat3Alpha !== 0) {
-      ctx.globalAlpha = this.splat3Alpha;
-      ctx.drawImage(splat3, 0, 0);
+      context.globalAlpha = this.splat3Alpha;
+      context.drawImage(splat3, 0, 0);
     }
     if (splat4 && this.splat4Alpha !== 0) {
-      ctx.globalAlpha = this.splat4Alpha;
-      ctx.drawImage(splat4, 0, 0);
+      context.globalAlpha = this.splat4Alpha;
+      context.drawImage(splat4, 0, 0);
     }
-    ctx.filter = "none";
+    context.filter = "none";
     if (rad && this.radAlpha !== 0) {
-      ctx.globalAlpha = this.radAlpha;
-      ctx.drawImage(rad, 0, 0);
+      context.globalAlpha = this.radAlpha;
+      context.drawImage(rad, 0, 0);
     }
 
     this.#composite = canvas;
@@ -198,16 +198,16 @@ export default class MapRenderer {
   }
 
   private drawPrefabs(
-    ctx: OffscreenCanvasRenderingContext2D,
+    context: OffscreenCanvasRenderingContext2D,
     width: number,
     height: number,
   ) {
-    ctx.font = `${this.signSize.toString()}px '${
+    context.font = `${this.signSize.toString()}px '${
       this.#fontFamilies[SIGN_CHAR]
     }'`;
-    ctx.fillStyle = "red";
-    ctx.textAlign = "center";
-    ctx.textBaseline = "middle";
+    context.fillStyle = "red";
+    context.textAlign = "center";
+    context.textBaseline = "middle";
 
     const offsetX = width / 2;
     const offsetY = height / 2;
@@ -220,23 +220,23 @@ export default class MapRenderer {
       const x = offsetX + prefab.x + charOffsetX;
       // prefab vertical positions are inverted for canvas coodinates
       const z = offsetY - prefab.z + charOffsetY;
-      putText(ctx, { text: SIGN_CHAR, x, z, size: this.signSize });
+      putText(context, { text: SIGN_CHAR, x, z, size: this.signSize });
     }
   }
 
   private drawMark(
-    ctx: OffscreenCanvasRenderingContext2D,
+    context: OffscreenCanvasRenderingContext2D,
     width: number,
     height: number,
   ) {
     if (!this.markerCoords) return;
 
-    ctx.font = `${this.signSize.toString()}px '${
+    context.font = `${this.signSize.toString()}px '${
       this.#fontFamilies[MARK_CHAR]
     }'`;
-    ctx.fillStyle = "red";
-    ctx.textAlign = "left";
-    ctx.textBaseline = "alphabetic";
+    context.fillStyle = "red";
+    context.textAlign = "left";
+    context.textBaseline = "alphabetic";
 
     const offsetX = width / 2;
     const offsetY = height / 2;
@@ -246,7 +246,7 @@ export default class MapRenderer {
     const x = offsetX + this.markerCoords.x + charOffsetX;
     const z = offsetY - this.markerCoords.z + charOffsetY;
 
-    putText(ctx, { text: MARK_CHAR, x, z, size: this.signSize });
+    putText(context, { text: MARK_CHAR, x, z, size: this.signSize });
   }
 
   size(): GameMapSize {
@@ -271,18 +271,18 @@ interface MapSign {
 }
 
 function putText(
-  ctx: OffscreenCanvasRenderingContext2D,
+  context: OffscreenCanvasRenderingContext2D,
   { text, x, z, size }: MapSign,
 ) {
-  ctx.lineWidth = Math.round(size * 0.2);
-  ctx.strokeStyle = "rgba(0, 0, 0, 0.8)";
-  ctx.strokeText(text, x, z);
+  context.lineWidth = Math.round(size * 0.2);
+  context.strokeStyle = "rgba(0, 0, 0, 0.8)";
+  context.strokeText(text, x, z);
 
-  ctx.lineWidth = Math.round(size * 0.1);
-  ctx.strokeStyle = "white";
-  ctx.strokeText(text, x, z);
+  context.lineWidth = Math.round(size * 0.1);
+  context.strokeStyle = "white";
+  context.strokeText(text, x, z);
 
-  ctx.fillText(text, x, z);
+  context.fillText(text, x, z);
 }
 
 /**

--- a/src/worker/lib/map-renderer.ts
+++ b/src/worker/lib/map-renderer.ts
@@ -103,13 +103,17 @@ export default class MapRenderer {
 
     const canvasWidth = Math.max(1, Math.round(width * this.scale));
     const canvasHeight = Math.max(1, Math.round(height * this.scale));
-    this.canvas.width = canvasWidth;
-    this.canvas.height = canvasHeight;
 
     const context = this.canvas.getContext("2d");
     if (!context) return;
 
+    // Compose the base map (which may re-decode at the new size) before
+    // touching the visible canvas. Resizing the canvas clears it, so doing it
+    // ahead of an await would expose a blank canvas and cause a flash while
+    // scaling; instead we resize and redraw in one synchronous pass below.
     const base = await this.#composeBase(canvasWidth, canvasHeight);
+    this.canvas.width = canvasWidth;
+    this.canvas.height = canvasHeight;
     context.imageSmoothingEnabled = false;
     if (base) context.drawImage(base, 0, 0);
 

--- a/src/worker/lib/map-renderer.ts
+++ b/src/worker/lib/map-renderer.ts
@@ -33,10 +33,10 @@ export default class MapRenderer {
   canvas: OffscreenCanvas;
   #mapSize = gameMapSize({ width: 0, height: 0 });
 
-  #biomesImage = new BitmapHolder("biomes.png");
-  #splat3Image = new BitmapHolder("splat3.png");
-  #splat4Image = new BitmapHolder("splat4.png");
-  #radImage = new BitmapHolder("radiation.png");
+  #biomesImage = new ScaledImageHolder("biomes.png");
+  #splat3Image = new ScaledImageHolder("splat3.png");
+  #splat4Image = new ScaledImageHolder("splat4.png");
+  #radImage = new ScaledImageHolder("radiation.png");
   #imageFiles = [
     this.#biomesImage,
     this.#splat3Image,
@@ -44,6 +44,13 @@ export default class MapRenderer {
     this.#radImage,
   ] as const;
   #fontFamilies: FontFamilies;
+
+  // Composited base map (layers + brightness + per-layer alpha) cached so that
+  // prefab/marker-only updates can skip recompositing.
+  #composite: OffscreenCanvas | null = null;
+  #compositeKey: string | null = null;
+  // Bumped whenever a source image is invalidated, to invalidate the composite.
+  #generation = 0;
 
   constructor(canvas: OffscreenCanvas, fontFamilies: FontFamilies) {
     this.canvas = canvas;
@@ -71,6 +78,7 @@ export default class MapRenderer {
           throw new Error(`Invalid file name: ${String(fileName)}`);
       }
     }
+    this.#generation++;
   }
 
   update = throttledInvoker(async () => {
@@ -81,11 +89,10 @@ export default class MapRenderer {
   });
 
   async #updateImmediately(): Promise<void> {
-    const [biomes, splat3, splat4, rad] = await Promise.all(
-      this.#imageFiles.map((i) => i.get()),
+    const sizes = await Promise.all(
+      this.#imageFiles.map((i) => i.nativeSize()),
     );
-
-    const { width, height } = mapSize(biomes, splat3, splat4, rad);
+    const { width, height } = mapSize(...sizes);
     this.#mapSize.width = width;
     this.#mapSize.height = height;
     if (width === 0 || height === 0) {
@@ -94,36 +101,21 @@ export default class MapRenderer {
       return;
     }
 
-    this.canvas.width = width * this.scale;
-    this.canvas.height = height * this.scale;
+    const canvasWidth = Math.max(1, Math.round(width * this.scale));
+    const canvasHeight = Math.max(1, Math.round(height * this.scale));
+    this.canvas.width = canvasWidth;
+    this.canvas.height = canvasHeight;
 
     const context = this.canvas.getContext("2d");
     if (!context) return;
+
+    const base = await this.#composeBase(canvasWidth, canvasHeight);
     context.imageSmoothingEnabled = false;
+    if (base) context.drawImage(base, 0, 0);
+
+    // Overlays are drawn in native map coordinates, scaled down to the canvas.
+    context.save();
     context.scale(this.scale, this.scale);
-    context.filter = `brightness(${this.brightness})`;
-
-    if (biomes && this.biomesAlpha !== 0) {
-      context.globalAlpha = this.biomesAlpha;
-      context.drawImage(biomes, 0, 0, width, height);
-    }
-    context.imageSmoothingEnabled = true;
-    if (splat3 && this.splat3Alpha !== 0) {
-      context.globalAlpha = this.splat3Alpha;
-      context.drawImage(splat3, 0, 0, width, height);
-    }
-    if (splat4 && this.splat4Alpha !== 0) {
-      context.globalAlpha = this.splat4Alpha;
-      context.drawImage(splat4, 0, 0, width, height);
-    }
-    context.imageSmoothingEnabled = false;
-
-    context.filter = "none";
-    if (rad && this.radAlpha !== 0) {
-      context.globalAlpha = this.radAlpha;
-      context.drawImage(rad, 0, 0, width, height);
-    }
-
     context.globalAlpha = this.signAlpha;
     if (this.showPrefabs) {
       this.drawPrefabs(context, width, height);
@@ -131,6 +123,74 @@ export default class MapRenderer {
     if (this.markerCoords) {
       this.drawMark(context, width, height);
     }
+    context.restore();
+  }
+
+  /**
+   * Composite the base layers (with brightness and per-layer alpha) onto a
+   * cached offscreen canvas at the current display resolution. The cache is
+   * reused as long as the display size, brightness, alphas, and source images
+   * are unchanged, so prefab/marker-only updates avoid re-decoding/compositing.
+   */
+  async #composeBase(
+    width: number,
+    height: number,
+  ): Promise<OffscreenCanvas | null> {
+    const key = [
+      width,
+      height,
+      this.brightness,
+      this.biomesAlpha,
+      this.splat3Alpha,
+      this.splat4Alpha,
+      this.radAlpha,
+      this.#generation,
+    ].join(":");
+    if (
+      this.#composite &&
+      this.#compositeKey === key &&
+      this.#composite.width === width &&
+      this.#composite.height === height
+    ) {
+      return this.#composite;
+    }
+
+    const [biomes, splat3, splat4, rad] = await Promise.all([
+      this.#biomesImage.get(width, height),
+      this.#splat3Image.get(width, height),
+      this.#splat4Image.get(width, height),
+      this.#radImage.get(width, height),
+    ]);
+
+    const canvas = this.#composite ?? new OffscreenCanvas(width, height);
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return null;
+    ctx.clearRect(0, 0, width, height);
+    ctx.filter = `brightness(${this.brightness})`;
+
+    if (biomes && this.biomesAlpha !== 0) {
+      ctx.globalAlpha = this.biomesAlpha;
+      ctx.drawImage(biomes, 0, 0);
+    }
+    if (splat3 && this.splat3Alpha !== 0) {
+      ctx.globalAlpha = this.splat3Alpha;
+      ctx.drawImage(splat3, 0, 0);
+    }
+    if (splat4 && this.splat4Alpha !== 0) {
+      ctx.globalAlpha = this.splat4Alpha;
+      ctx.drawImage(splat4, 0, 0);
+    }
+    ctx.filter = "none";
+    if (rad && this.radAlpha !== 0) {
+      ctx.globalAlpha = this.radAlpha;
+      ctx.drawImage(rad, 0, 0);
+    }
+
+    this.#composite = canvas;
+    this.#compositeKey = key;
+    return canvas;
   }
 
   private drawPrefabs(
@@ -190,10 +250,12 @@ export default class MapRenderer {
   }
 }
 
-function mapSize(...images: (ImageBitmap | null | undefined)[]): GameMapSize {
+function mapSize(
+  ...sizes: ({ width: number; height: number } | null | undefined)[]
+): GameMapSize {
   return gameMapSize({
-    width: Math.max(...images.map((i) => i?.width ?? 0)),
-    height: Math.max(...images.map((i) => i?.height ?? 0)),
+    width: Math.max(0, ...sizes.map((s) => s?.width ?? 0)),
+    height: Math.max(0, ...sizes.map((s) => s?.height ?? 0)),
   });
 }
 
@@ -219,29 +281,90 @@ function putText(
   ctx.fillText(text, x, z);
 }
 
-class BitmapHolder extends CacheHolder<ImageBitmap | null> {
+/**
+ * Holds a source map image, decoding it lazily at the requested display
+ * resolution rather than at full resolution. The decoded bitmap is cached
+ * (with TTL) and re-decoded only when the requested size changes or the
+ * source image is invalidated, keeping memory proportional to the displayed
+ * size instead of the native image size.
+ */
+class ScaledImageHolder {
+  #targetWidth = 0;
+  #targetHeight = 0;
+  #nativeSize: { width: number; height: number } | null = null;
+  #holder: CacheHolder<ImageBitmap | null>;
+
   constructor(readonly fileName: mapFiles.MapFileName) {
-    super(
-      async () => {
-        console.time(`Loading image ${fileName}`);
-        const workspace = await storage.workspaceDir();
-        const file = await workspace.get(fileName);
-        try {
-          const result = file ? await createImageBitmap(file) : null;
-          console.log("Loaded image", fileName);
-          return result;
-        } catch (e) {
-          const extra = file
-            ? `(size: ${file.size} bytes, type: ${file.type})`
-            : "(file not found)";
-          throw new Error(`Failed to decode image: ${fileName} ${extra}`, {
-            cause: e,
-          });
-        } finally {
-          console.timeEnd(`Loading image ${fileName}`);
-        }
-      },
+    this.#holder = new CacheHolder<ImageBitmap | null>(
+      () => this.#decode(),
       (img) => img?.close(),
     );
   }
+
+  invalidate() {
+    this.#nativeSize = null;
+    this.#holder.invalidate();
+  }
+
+  async nativeSize(): Promise<{ width: number; height: number } | null> {
+    if (this.#nativeSize) return this.#nativeSize;
+    const file = await this.#getFile();
+    if (!file) return null;
+    this.#nativeSize = await readPngSize(file);
+    return this.#nativeSize;
+  }
+
+  get(width: number, height: number): Promise<ImageBitmap | null> {
+    if (width !== this.#targetWidth || height !== this.#targetHeight) {
+      this.#targetWidth = width;
+      this.#targetHeight = height;
+      this.#holder.invalidate();
+    }
+    return this.#holder.get();
+  }
+
+  async #getFile(): Promise<File | null> {
+    const workspace = await storage.workspaceDir();
+    return workspace.get(this.fileName);
+  }
+
+  async #decode(): Promise<ImageBitmap | null> {
+    const width = this.#targetWidth;
+    const height = this.#targetHeight;
+    if (width <= 0 || height <= 0) return null;
+    console.time(`Loading image ${this.fileName}`);
+    const file = await this.#getFile();
+    try {
+      if (!file) return null;
+      const result = await createImageBitmap(file, {
+        resizeWidth: width,
+        resizeHeight: height,
+        resizeQuality: "high",
+      });
+      console.log("Loaded image", this.fileName, width, height);
+      return result;
+    } catch (e) {
+      const extra = file
+        ? `(size: ${file.size} bytes, type: ${file.type})`
+        : "(file not found)";
+      throw new Error(`Failed to decode image: ${this.fileName} ${extra}`, {
+        cause: e,
+      });
+    } finally {
+      console.timeEnd(`Loading image ${this.fileName}`);
+    }
+  }
+}
+
+/**
+ * Read width/height from a PNG's IHDR chunk without decoding pixels.
+ * Layout: 8-byte signature, 4-byte chunk length, 4-byte "IHDR" type,
+ * then 4-byte width and 4-byte height (big-endian).
+ */
+async function readPngSize(
+  file: Blob,
+): Promise<{ width: number; height: number }> {
+  const header = await file.slice(0, 24).arrayBuffer();
+  const view = new DataView(header);
+  return { width: view.getUint32(16), height: view.getUint32(20) };
 }


### PR DESCRIPTION
## Summary

- The map renderer worker previously decoded each layer (biomes/splat3/splat4/radiation) into a full-resolution RGBA bitmap and held all four in memory. That cost `width × height × 4` bytes per layer regardless of display scale — roughly 1 GB for an 8192² map, 4 GB for 16384².
- Layers are now decoded at the current **display** resolution using `createImageBitmap`'s `resizeWidth`/`resizeHeight`/`resizeQuality` options, so memory scales with displayed size, not native image size. Native dimensions are read cheaply from the PNG IHDR header.
- Only a single **composited base-map** (`OffscreenCanvas`) is retained. Per-layer bitmaps are released immediately after compositing via a `finally` block.
- The composite is cached and reused when only prefabs/marker change, so those frequent updates skip recompositing and re-decoding entirely.
- The cache is keyed by display size / brightness / alphas / image generation; prefab/marker moves reuse the cached composite without any re-decode.
- Blank-canvas flash on scale change is eliminated: compositing completes on the offscreen canvas before the visible canvas is resized.
- `MAP_IMAGE_FILE_NAMES` (the four rendering-layer image files) is now exported from `lib/map-files.ts`, and `MapFileName` is derived directly from `FILE_PROCESS_RULES` without intermediate generic types.

## Memory model

| Before | After |
|---|---|
| 4× full-resolution layer bitmaps + composite | composite only (at display resolution) |

## Test plan

- [x] `deno task ci` passes
- [x] Manually verified with the bundled Navezgane map:
  - Default render, scale 0.5, scale 0.06 — layers render correctly at each size
  - Drag scale slider — no white-canvas flash
  - Toggle biomes/splat3/splat4/radiation alpha — layers update correctly
  - Drag brightness slider — applies to biomes/splat3/splat4 only; radiation unaffected
  - Move prefab marker — updates without re-compositing

🤖 Generated with [Claude Code](https://claude.com/claude-code)