### PR TITLE
Cache only the composite, not per-layer bitmaps

### DIFF
--- a/lib/map-files.ts
+++ b/lib/map-files.ts
@@ -47,14 +47,14 @@ const FILE_PROCESS_RULES = {
 } as const;
 
 export type WorldFileName = keyof typeof FILE_PROCESS_RULES;
-export type MapFileNameMap<T extends keyof typeof FILE_PROCESS_RULES> =
-  (typeof FILE_PROCESS_RULES)[T]["name"];
-export const MAP_FILE_NAME_MAP = Object.fromEntries(
-  Object.entries(FILE_PROCESS_RULES).map(([k, v]) => [k, v.name]),
-) as {
-  [K in WorldFileName]: MapFileNameMap<K>;
-};
-export type MapFileName = MapFileNameMap<WorldFileName>;
+export type MapFileName = (typeof FILE_PROCESS_RULES)[WorldFileName]["name"];
+
+export const MAP_IMAGE_FILE_NAMES = [
+  "biomes.png",
+  "splat3.png",
+  "splat4.png",
+  "radiation.png",
+] as const satisfies readonly MapFileName[];
 
 export class Processor<T extends keyof typeof FILE_PROCESS_RULES> {
   #worldFileName: T;
@@ -63,7 +63,7 @@ export class Processor<T extends keyof typeof FILE_PROCESS_RULES> {
     this.#worldFileName = worldFileName;
   }
 
-  get mapFileName(): MapFileNameMap<T> {
+  get mapFileName(): MapFileName {
     return FILE_PROCESS_RULES[this.#worldFileName].name;
   }
 
@@ -89,19 +89,11 @@ export const MAP_FILE_NAMES = new Set(
   Object.values(FILE_PROCESS_RULES).map((v) => v.name),
 );
 
-export function isMapFileName(
-  name: string,
-): name is MapFileNameMap<WorldFileName> {
-  return MAP_FILE_NAMES.has(
-    name as unknown as (typeof FILE_PROCESS_RULES)[
-      keyof typeof FILE_PROCESS_RULES
-    ]["name"],
-  );
+export function isMapFileName(name: string): name is MapFileName {
+  return MAP_FILE_NAMES.has(name as MapFileName);
 }
 
-export function getMapFileName(
-  name: WorldFileName,
-): MapFileNameMap<WorldFileName> {
+export function getMapFileName(name: WorldFileName): MapFileName {
   return FILE_PROCESS_RULES[name].name;
 }
 

--- a/src/worker/lib/map-renderer.ts
+++ b/src/worker/lib/map-renderer.ts
@@ -16,6 +16,13 @@ interface FontFamilies {
   [MARK_CHAR]: string;
 }
 
+const MAP_FILE_NAMES = [
+  "biomes.png",
+  "splat3.png",
+  "splat4.png",
+  "radiation.png",
+] as const satisfies readonly mapFiles.MapFileName[];
+
 export default class MapRenderer {
   brightness = "100%";
   markerCoords: GameCoords | null = null;
@@ -31,18 +38,12 @@ export default class MapRenderer {
 
   canvas: OffscreenCanvas;
   #mapSize = gameMapSize({ width: 0, height: 0 });
-
-  #biomesImage = new MapLayerImage("biomes.png");
-  #splat3Image = new MapLayerImage("splat3.png");
-  #splat4Image = new MapLayerImage("splat4.png");
-  #radImage = new MapLayerImage("radiation.png");
-  #imageFiles = [
-    this.#biomesImage,
-    this.#splat3Image,
-    this.#splat4Image,
-    this.#radImage,
-  ] as const;
   #fontFamilies: FontFamilies;
+
+  #nativeSizes = new Map<
+    mapFiles.MapFileName,
+    { width: number; height: number }
+  >();
 
   // Composited base map (layers + brightness + per-layer alpha) cached so that
   // prefab/marker-only updates can skip recompositing.
@@ -60,22 +61,7 @@ export default class MapRenderer {
     fileNames: ("biomes.png" | "splat3.png" | "splat4.png" | "radiation.png")[],
   ) {
     for (const fileName of fileNames) {
-      switch (fileName) {
-        case "biomes.png":
-          this.#biomesImage.invalidate();
-          break;
-        case "splat3.png":
-          this.#splat3Image.invalidate();
-          break;
-        case "splat4.png":
-          this.#splat4Image.invalidate();
-          break;
-        case "radiation.png":
-          this.#radImage.invalidate();
-          break;
-        default:
-          throw new Error(`Invalid file name: ${String(fileName)}`);
-      }
+      this.#nativeSizes.delete(fileName);
     }
     this.#generation++;
   }
@@ -89,7 +75,7 @@ export default class MapRenderer {
 
   async #updateImmediately(): Promise<void> {
     const sizes = await Promise.all(
-      this.#imageFiles.map((i) => i.nativeSize()),
+      MAP_FILE_NAMES.map((f) => this.#nativeSize(f)),
     );
     const { width, height } = mapSize(...sizes);
     this.#mapSize.width = width;
@@ -165,10 +151,10 @@ export default class MapRenderer {
     if (!context) throw new Error("Failed to get 2d context");
 
     const [biomes, splat3, splat4, rad] = await Promise.all([
-      this.#biomesImage.decode(width, height),
-      this.#splat3Image.decode(width, height),
-      this.#splat4Image.decode(width, height),
-      this.#radImage.decode(width, height),
+      this.#decode("biomes.png", width, height),
+      this.#decode("splat3.png", width, height),
+      this.#decode("splat4.png", width, height),
+      this.#decode("radiation.png", width, height),
     ]);
 
     try {
@@ -254,6 +240,50 @@ export default class MapRenderer {
     putText(context, { text: MARK_CHAR, x, z, size: this.signSize });
   }
 
+  async #nativeSize(
+    fileName: mapFiles.MapFileName,
+  ): Promise<{ width: number; height: number } | null> {
+    const cached = this.#nativeSizes.get(fileName);
+    if (cached) return cached;
+    const file = await this.#getFile(fileName);
+    if (!file) return null;
+    const size = await readPngSize(file);
+    this.#nativeSizes.set(fileName, size);
+    return size;
+  }
+
+  async #decode(
+    fileName: mapFiles.MapFileName,
+    width: number,
+    height: number,
+  ): Promise<ImageBitmap | null> {
+    if (width <= 0 || height <= 0) return null;
+    const file = await this.#getFile(fileName);
+    if (!file) return null;
+    console.time(`Loading image ${fileName}`);
+    try {
+      const result = await createImageBitmap(file, {
+        resizeWidth: width,
+        resizeHeight: height,
+        resizeQuality: "high",
+      });
+      console.log("Loaded image", fileName, width, height);
+      return result;
+    } catch (e) {
+      const extra = `(size: ${file.size} bytes, type: ${file.type})`;
+      throw new Error(`Failed to decode image: ${fileName} ${extra}`, {
+        cause: e,
+      });
+    } finally {
+      console.timeEnd(`Loading image ${fileName}`);
+    }
+  }
+
+  async #getFile(fileName: mapFiles.MapFileName): Promise<File | null> {
+    const workspace = await storage.workspaceDir();
+    return workspace.get(fileName);
+  }
+
   size(): GameMapSize {
     return this.#mapSize;
   }
@@ -288,60 +318,6 @@ function putText(
   context.strokeText(text, x, z);
 
   context.fillText(text, x, z);
-}
-
-/**
- * Accesses a source map image, decoding it at the requested display resolution
- * rather than at full resolution. The decoded bitmap is NOT retained: the
- * caller owns the returned bitmap and must close() it. Only the native
- * dimensions (read cheaply from the PNG header) are memoized. This keeps just
- * the single composited surface in memory, at the cost of re-decoding the
- * layers whenever the composite is rebuilt.
- */
-class MapLayerImage {
-  #nativeSize: { width: number; height: number } | null = null;
-
-  constructor(readonly fileName: mapFiles.MapFileName) {}
-
-  invalidate() {
-    this.#nativeSize = null;
-  }
-
-  async nativeSize(): Promise<{ width: number; height: number } | null> {
-    if (this.#nativeSize) return this.#nativeSize;
-    const file = await this.#getFile();
-    if (!file) return null;
-    this.#nativeSize = await readPngSize(file);
-    return this.#nativeSize;
-  }
-
-  async decode(width: number, height: number): Promise<ImageBitmap | null> {
-    if (width <= 0 || height <= 0) return null;
-    const file = await this.#getFile();
-    if (!file) return null;
-    console.time(`Loading image ${this.fileName}`);
-    try {
-      const result = await createImageBitmap(file, {
-        resizeWidth: width,
-        resizeHeight: height,
-        resizeQuality: "high",
-      });
-      console.log("Loaded image", this.fileName, width, height);
-      return result;
-    } catch (e) {
-      const extra = `(size: ${file.size} bytes, type: ${file.type})`;
-      throw new Error(`Failed to decode image: ${this.fileName} ${extra}`, {
-        cause: e,
-      });
-    } finally {
-      console.timeEnd(`Loading image ${this.fileName}`);
-    }
-  }
-
-  async #getFile(): Promise<File | null> {
-    const workspace = await storage.workspaceDir();
-    return workspace.get(this.fileName);
-  }
 }
 
 /**

--- a/src/worker/lib/map-renderer.ts
+++ b/src/worker/lib/map-renderer.ts
@@ -7,7 +7,6 @@ import { throttledInvoker } from "../../lib/throttled-invoker.ts";
 import { gameMapSize } from "../../lib/utils.ts";
 import * as storage from "../../lib/storage.ts";
 import * as mapFiles from "../../../lib/map-files.ts";
-import { CacheHolder } from "../../lib/cache-holder.ts";
 
 const SIGN_CHAR = "✘";
 const MARK_CHAR = "🚩";
@@ -33,10 +32,10 @@ export default class MapRenderer {
   canvas: OffscreenCanvas;
   #mapSize = gameMapSize({ width: 0, height: 0 });
 
-  #biomesImage = new ScaledImageHolder("biomes.png");
-  #splat3Image = new ScaledImageHolder("splat3.png");
-  #splat4Image = new ScaledImageHolder("splat4.png");
-  #radImage = new ScaledImageHolder("radiation.png");
+  #biomesImage = new MapLayerImage("biomes.png");
+  #splat3Image = new MapLayerImage("splat3.png");
+  #splat4Image = new MapLayerImage("splat4.png");
+  #radImage = new MapLayerImage("radiation.png");
   #imageFiles = [
     this.#biomesImage,
     this.#splat3Image,
@@ -159,37 +158,43 @@ export default class MapRenderer {
       return this.#composite;
     }
 
-    const [biomes, splat3, splat4, rad] = await Promise.all([
-      this.#biomesImage.get(width, height),
-      this.#splat3Image.get(width, height),
-      this.#splat4Image.get(width, height),
-      this.#radImage.get(width, height),
-    ]);
-
     const canvas = this.#composite ?? new OffscreenCanvas(width, height);
     canvas.width = width;
     canvas.height = height;
     const context = canvas.getContext("2d");
     if (!context) throw new Error("Failed to get 2d context");
-    context.clearRect(0, 0, width, height);
-    context.filter = `brightness(${this.brightness})`;
 
-    if (biomes && this.biomesAlpha !== 0) {
-      context.globalAlpha = this.biomesAlpha;
-      context.drawImage(biomes, 0, 0);
-    }
-    if (splat3 && this.splat3Alpha !== 0) {
-      context.globalAlpha = this.splat3Alpha;
-      context.drawImage(splat3, 0, 0);
-    }
-    if (splat4 && this.splat4Alpha !== 0) {
-      context.globalAlpha = this.splat4Alpha;
-      context.drawImage(splat4, 0, 0);
-    }
-    context.filter = "none";
-    if (rad && this.radAlpha !== 0) {
-      context.globalAlpha = this.radAlpha;
-      context.drawImage(rad, 0, 0);
+    const [biomes, splat3, splat4, rad] = await Promise.all([
+      this.#biomesImage.decode(width, height),
+      this.#splat3Image.decode(width, height),
+      this.#splat4Image.decode(width, height),
+      this.#radImage.decode(width, height),
+    ]);
+
+    try {
+      context.clearRect(0, 0, width, height);
+      context.filter = `brightness(${this.brightness})`;
+
+      if (biomes && this.biomesAlpha !== 0) {
+        context.globalAlpha = this.biomesAlpha;
+        context.drawImage(biomes, 0, 0);
+      }
+      if (splat3 && this.splat3Alpha !== 0) {
+        context.globalAlpha = this.splat3Alpha;
+        context.drawImage(splat3, 0, 0);
+      }
+      if (splat4 && this.splat4Alpha !== 0) {
+        context.globalAlpha = this.splat4Alpha;
+        context.drawImage(splat4, 0, 0);
+      }
+      context.filter = "none";
+      if (rad && this.radAlpha !== 0) {
+        context.globalAlpha = this.radAlpha;
+        context.drawImage(rad, 0, 0);
+      }
+    } finally {
+      // Only the composite is cached; release the per-layer bitmaps.
+      for (const bitmap of [biomes, splat3, splat4, rad]) bitmap?.close();
     }
 
     this.#composite = canvas;
@@ -286,28 +291,20 @@ function putText(
 }
 
 /**
- * Holds a source map image, decoding it lazily at the requested display
- * resolution rather than at full resolution. The decoded bitmap is cached
- * (with TTL) and re-decoded only when the requested size changes or the
- * source image is invalidated, keeping memory proportional to the displayed
- * size instead of the native image size.
+ * Accesses a source map image, decoding it at the requested display resolution
+ * rather than at full resolution. The decoded bitmap is NOT retained: the
+ * caller owns the returned bitmap and must close() it. Only the native
+ * dimensions (read cheaply from the PNG header) are memoized. This keeps just
+ * the single composited surface in memory, at the cost of re-decoding the
+ * layers whenever the composite is rebuilt.
  */
-class ScaledImageHolder {
-  #targetWidth = 0;
-  #targetHeight = 0;
+class MapLayerImage {
   #nativeSize: { width: number; height: number } | null = null;
-  #holder: CacheHolder<ImageBitmap | null>;
 
-  constructor(readonly fileName: mapFiles.MapFileName) {
-    this.#holder = new CacheHolder<ImageBitmap | null>(
-      () => this.#decode(),
-      (img) => img?.close(),
-    );
-  }
+  constructor(readonly fileName: mapFiles.MapFileName) {}
 
   invalidate() {
     this.#nativeSize = null;
-    this.#holder.invalidate();
   }
 
   async nativeSize(): Promise<{ width: number; height: number } | null> {
@@ -318,28 +315,12 @@ class ScaledImageHolder {
     return this.#nativeSize;
   }
 
-  get(width: number, height: number): Promise<ImageBitmap | null> {
-    if (width !== this.#targetWidth || height !== this.#targetHeight) {
-      this.#targetWidth = width;
-      this.#targetHeight = height;
-      this.#holder.invalidate();
-    }
-    return this.#holder.get();
-  }
-
-  async #getFile(): Promise<File | null> {
-    const workspace = await storage.workspaceDir();
-    return workspace.get(this.fileName);
-  }
-
-  async #decode(): Promise<ImageBitmap | null> {
-    const width = this.#targetWidth;
-    const height = this.#targetHeight;
+  async decode(width: number, height: number): Promise<ImageBitmap | null> {
     if (width <= 0 || height <= 0) return null;
-    console.time(`Loading image ${this.fileName}`);
     const file = await this.#getFile();
+    if (!file) return null;
+    console.time(`Loading image ${this.fileName}`);
     try {
-      if (!file) return null;
       const result = await createImageBitmap(file, {
         resizeWidth: width,
         resizeHeight: height,
@@ -348,15 +329,18 @@ class ScaledImageHolder {
       console.log("Loaded image", this.fileName, width, height);
       return result;
     } catch (e) {
-      const extra = file
-        ? `(size: ${file.size} bytes, type: ${file.type})`
-        : "(file not found)";
+      const extra = `(size: ${file.size} bytes, type: ${file.type})`;
       throw new Error(`Failed to decode image: ${this.fileName} ${extra}`, {
         cause: e,
       });
     } finally {
       console.timeEnd(`Loading image ${this.fileName}`);
     }
+  }
+
+  async #getFile(): Promise<File | null> {
+    const workspace = await storage.workspaceDir();
+    return workspace.get(this.fileName);
   }
 }
 

--- a/src/worker/lib/map-renderer.ts
+++ b/src/worker/lib/map-renderer.ts
@@ -16,13 +16,6 @@ interface FontFamilies {
   [MARK_CHAR]: string;
 }
 
-const MAP_FILE_NAMES = [
-  "biomes.png",
-  "splat3.png",
-  "splat4.png",
-  "radiation.png",
-] as const satisfies readonly mapFiles.MapFileName[];
-
 export default class MapRenderer {
   brightness = "100%";
   markerCoords: GameCoords | null = null;
@@ -75,7 +68,7 @@ export default class MapRenderer {
 
   async #updateImmediately(): Promise<void> {
     const sizes = await Promise.all(
-      MAP_FILE_NAMES.map((f) => this.#nativeSize(f)),
+      mapFiles.MAP_IMAGE_FILE_NAMES.map((f) => this.#nativeSize(f)),
     );
     const { width, height } = mapSize(...sizes);
     this.#mapSize.width = width;
@@ -150,12 +143,9 @@ export default class MapRenderer {
     const context = canvas.getContext("2d");
     if (!context) throw new Error("Failed to get 2d context");
 
-    const [biomes, splat3, splat4, rad] = await Promise.all([
-      this.#decode("biomes.png", width, height),
-      this.#decode("splat3.png", width, height),
-      this.#decode("splat4.png", width, height),
-      this.#decode("radiation.png", width, height),
-    ]);
+    const [biomes, splat3, splat4, rad] = await Promise.all(
+      mapFiles.MAP_IMAGE_FILE_NAMES.map((f) => this.#decode(f, width, height)),
+    );
 
     try {
       context.clearRect(0, 0, width, height);


### PR DESCRIPTION
## Summary

- Replaces the two-tier cache from #129 (per-layer scaled bitmap cache + composite cache) with a single composite-only cache.
- After compositing, per-layer `ImageBitmap` objects are immediately closed in a `finally` block — they are never retained beyond the compositing step.
- The composite `OffscreenCanvas` is still cached and reused as long as the display size, brightness, per-layer alpha values, and source image generation are unchanged, so prefab/marker-only updates remain cheap.
- Re-decoding all layers on alpha/brightness/scale changes is the accepted trade-off for lower peak memory usage.

## Memory model comparison

| Approach | Memory held between renders |
|---|---|
| PR #129 (two-tier) | composite + 4× scaled layer bitmaps |
| This PR (composite-only) | composite only |

## Why this is safe despite re-decoding

UI slider smoothness is unaffected: the canvas lives in a worker, and the main thread never blocks on decode. The throttled invoker (100 ms) absorbs rapid slider changes; only the final settled state triggers a full re-composite.

## Test plan

- [x] Load a map and verify all layers render correctly
- [x] Drag the scale slider — no white-canvas flash should appear
- [x] Toggle biomes/splat3/splat4/radiation alpha sliders — map updates correctly (re-decode path)
- [x] Drag brightness slider — brightness applies to biomes/splat3/splat4 only, radiation is unaffected
- [x] Move the prefab marker — updates without re-compositing layers

🤖 Generated with [Claude Code](https://claude.com/claude-code)